### PR TITLE
Fix install fvm issue

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Install FVM
-pub global activate fvm
+dart pub global activate fvm
 export PATH="$PATH":"$HOME/.pub-cache/bin"
 fvm install
 


### PR DESCRIPTION
The step is throwing this error `pub: command not found` when the script executes `pub global activate fvm`, 